### PR TITLE
Material colors, better demo and docs, new default size

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,7 @@
   "homepage": "https://github.com/timeu/svg-piechart/",
   "ignore": [
     "/.*",
-    "/test/",
-    "/demo/"
+    "/test/"
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.0.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,19 +1,71 @@
 <!doctype html>
 <html>
-<head>
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>svg-piechart Demo</title>
+  <head>
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>svg-piechart</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../svg-piechart.html">
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../svg-piechart.html">
+    <link rel="import" href="../../paper-styles/demo-pages.html">
 
-</head>
-<body>
+    <style is="custom-style">
+      .vertical-section-container {
+        max-width: 48em;
+        margin: 0 auto;
+      }
+      .horizontal-section {
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
 
-  <p>An example of using <code>&lt;svg-piechart></code>:</p>
+    <div class="vertical-section-container">
+      <div>
+        <h4>Normal</h4>
+        <div class="horizontal-section">
+          <svg-piechart data="[10,50,20,10]"></svg-piechart>
+        </div>
+      </div>
+      <div>
+        <h4>Bigger (<code>size</code> is <code>250</code>)</h4>
+        <div class="horizontal-section">
+          <svg-piechart size="250" data="[10,50,20,10]"></svg-piechart>
+        </div>
+      </div>
+      <div>
+        <h4>Custom colors</h4>
+        <div class="horizontal-section">
+          <svg-piechart
+            colors='[
+              "rgba(255, 0, 0, .1)",
+              "rgba(255, 0, 0, .3)",
+              "rgba(255, 0, 0, .5)",
+              "rgba(255, 0, 0, .7)",
+              "rgba(255, 0, 0, .9)"]'
+            data="[1,1,1,1,1]">
+          </svg-piechart>
+        </div>
+      </div>
+      <div>
+        <h4>Smallest default color palette (up to 4 different colors)</h4>
+        <div class="horizontal-section">
+          <svg-piechart data="[1,1,1,1]"></svg-piechart>
+        </div>
+      </div>
+      <div>
+        <h4>Mid-size default color palette (up to 8 different colors)</h4>
+        <div class="horizontal-section">
+          <svg-piechart data="[1,1,1,1,1,1,1,1]"></svg-piechart>
+        </div>
+      </div>
+      <div>
+        <h4>Biggest default color palette (up to 16 different colors)</h4>
+        <div class="horizontal-section">
+          <svg-piechart data="[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]"></svg-piechart>
+        </div>
+      </div>
+    </div>
 
-  <svg-piechart size="250" data="[10,50,20,10]"></svg-piechart>
-  
-
-</body>
+  </body>
 </html>

--- a/svg-piechart.html
+++ b/svg-piechart.html
@@ -16,126 +16,181 @@ The `svg-piechart` element draws a piechart using SVG
 
 <dom-module id="svg-piechart">
   <style>
-     :host {
-       display:block;
-     }
-     .slice {
-     }
+    :host {
+      display:block;
+    }
+
+    .slice:hover + text {
+    }
    </style>
    
    <template>
-     <svg id="svg" width$="[[size]]" height$="[[size]]" viewBox="0 0 360 360">
-       <!-- 
-              <template is="dom-repeat"  {{_arcs}}>
-       <path class="slice" d="M180,180 L{{item.x1}},{{item.y1}} A180,180 0 {{item.largeArcFlag}},1 {{item.x2}},{{item.y2}} z"style="fill: {{item.color}}"/>
-      </template>-->
+    <svg id="svg" width$="[[size]]" height$="[[size]]" viewBox="0 0 360 360">
+      <!-- <template is="dom-repeat" items={{_arcs}}>
+          <path class="slice" d="M180,180 L{{item.x1}},{{item.y1}} A180,180 0 {{item.largeArcFlag}},1 {{item.x2}},{{item.y2}} z"style="fill: {{item.color}}" />
+      </template> -->
     </svg>
   </template>
   
 </dom-module>
 
 <script>
-     (function() {
+(function() {
 
-       var DEFAULT_COLORS20  =  ["#1f77b4", "#aec7e8", "#ff7f0e", "#ffbb78", "#2ca02c", "#98df8a", "#d62728", "#ff9896", "#9467bd", "#c5b0d5", "#8c564b", "#c49c94", "#e377c2", "#f7b6d2", "#7f7f7f", "#c7c7c7", "#bcbd22", "#dbdb8d", "#17becf", "#9edae5"];
-       var DEFAULT_COLORS10  =  ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"];
+  var DEFAULT_COLORS16 = [
+    '#f44336',
+    '#e91e63',
+    '#9c27b0',
+    '#673ab7',
+    '#3f51b5',
+    '#1e88e5',
+    '#03a9f4',
+    '#00bcd4',
+    '#009688',
+    '#4caf50',
+    '#8bc34a',
+    '#cddc39',
+    '#ffeb3b',
+    '#ffc107',
+    '#ff9800',
+    '#ff5722'
+  ];
+  var DEFAULT_COLORS8 = [
+    '#f44336',
+    '#9c27b0',
+    '#3f51b5',
+    '#03a9f4',
+    '#009688',
+    '#8bc34a',
+    '#ffeb3b',
+    '#ff9800'
+  ];
+  var DEFAULT_COLORS4 = [
+    '#f44336',
+    '#3f51b5',
+    '#8bc34a',
+    '#ffeb3b',
+  ];
 
 
-       Polymer({
-         
-         is: 'svg-piechart',
-         
-         properties: {
-             /**
-             * The `colors` attribute specifies the colors to be used for each slice.
-             * If no colors are specified then the default-colors are used.
-             * 
-             * @attribute colors
-             */
-            colors: {
-                type:Array,
-                value:function() {return []}
-            },
-            
-             /**
-             * The `size` property specifies the size of the piechart (Default: 50).
-             * 
-             * @attribute size
-             */
-            size: {
-               type:Number,
-               value:50
-            },
-            
-            /**
-             * The `data` property specifies the values for each slice .
-             * 
-             * @attribute data
-            */
-            data : {
-               type:Array,
-               value: function() { return []; }
-            } 
-         },
-         
-         observers: [
-             '_render(colors,data)'
-         ],
-         _calculateTotal: function(data) {
-          var total = 0;
-          for (var i =0;i<data.length;i++) {
-            total += data[i];
-          }
-          return total;
+  Polymer({
 
-         },
-         _computePath: function(arc) {
-             return "M180,180 L"+arc.x1+","+arc.y1+" A180,180 0 "+arc.largeArcFlag+",1 "+arc.x2+","+arc.y2+" z";
-         },
-         _getColors : function(colors) {
-            if (!colors || colors.length == 0) {
-              colors = this.data.length > 10  ? DEFAULT_COLORS20 : DEFAULT_COLORS10;
-            }
-            return colors;
-         },
-         _calculateArcs : function(colors,data) {
-           var total = this._calculateTotal(data);
-           var colors = this._getColors(colors);
-           var startAngle =  0;
-           var endAngle = -90;
-           var arcs = [];
-           for(var i=0; i < data.length; i++){
-                var angle = (360 * data[i]/total);
-                var largeArcFlag=0;
-                if (angle>180) {largeArcFlag = 1;}
-                
-                startAngle = endAngle;
-                endAngle = startAngle + angle;
+    is: 'svg-piechart',
 
-                x1 = ((180 + 180*Math.cos(Math.PI*startAngle/180)));
-                y1 = ((180 + 180*Math.sin(Math.PI*startAngle/180)));
-                x2 = ((180 + 180*Math.cos(Math.PI*endAngle/180)));
-                y2 = ((180 + 180*Math.sin(Math.PI*endAngle/180))); 
-                color = colors[i];
-                arcs.push({x1:x1,y1:y1,x2:x2,y2:y2,largeArcFlag:largeArcFlag,color:color});
+    properties: {
+      /**
+      * The `colors` attribute specifies the colors to be used for each slice.
+      * If no colors are specified then the default-colors are used.
+      * 
+      * @attribute colors
+      */
+      colors: {
+        type: Array,
+        value: function() {
+          return [];
+        }
+      },
 
-            }
-            return arcs;
-         },
-         _render : function(colors,data) {
-           var arcs = this._calculateArcs(colors,data);
-           var svg = Polymer.dom(this.$.svg);
-           while (svg.firstChild) {
-              svg.removeChild(svg.firstChild);
-           }
-           for (i =0;i<arcs.length;i++) {
-              var path = document.createElementNS('http://www.w3.org/2000/svg',"path");
-              path.classList.add("slice");
-              path.style.fill= arcs[i].color;
-              path.setAttributeNS(null,"d",this._computePath(arcs[i]));
-              svg.appendChild(path);
-           }
-         }
-     })
-   })();
+      /**
+      * The `size` property specifies the size of the piechart (Default: 50).
+      * 
+      * @attribute size
+      */
+      size: {
+        type: Number,
+        value: 50
+      },
+
+      /**
+      * The `data` property specifies the values for each slice .
+      * 
+      * @attribute data
+      */
+      data : {
+        type: Array,
+        value: function() {
+          return [];
+        }
+      } 
+    },
+
+    observers: [
+      '_render(colors, data)'
+    ],
+
+    _calculateTotal: function(data) {
+      var total = 0;
+      for (var i = 0; i < data.length; i++) {
+        total += data[i];
+      }
+      return total;
+    },
+
+    _computePath: function(arc) {
+      return "M180,180 L" + arc.x1 + "," + arc.y1 + " A180,180 0 " + arc.largeArcFlag + ",1 " + arc.x2 + "," + arc.y2 + " z";
+    },
+
+    _getColors: function(colors) {
+      if (!colors || colors.length == 0) {
+        // colors = this.data.length > 10  ? DEFAULT_COLORS20 : DEFAULT_COLORS10;
+        if (this.data.length > 8) {
+          colors = DEFAULT_COLORS16;
+        }
+        else if (this.data.length > 4) {
+          colors = DEFAULT_COLORS8;
+        }
+        else {
+          colors = DEFAULT_COLORS4;
+        }
+      }
+      return colors;
+    },
+
+    _calculateArcs: function(colors, data) {
+      var total = this._calculateTotal(data);
+      var colors = this._getColors(colors);
+      var startAngle =  0;
+      var endAngle = -90;
+      var arcs = [];
+
+      for (var i = 0; i < data.length; i++) {
+        var angle = (360*data[i]/total);
+        var largeArcFlag = 0;
+        if (angle > 180) {
+          largeArcFlag = 1;
+        }
+
+        startAngle = endAngle;
+        endAngle = startAngle + angle;
+
+        arcs.push({
+          x1: 180 + 180*Math.cos(Math.PI*startAngle/180),
+          y1: 180 + 180*Math.sin(Math.PI*startAngle/180),
+          x2: 180 + 180*Math.cos(Math.PI*endAngle/180),
+          y2: 180 + 180*Math.sin(Math.PI*endAngle/180),
+          largeArcFlag: largeArcFlag,
+          color: colors[i]});
+      }
+
+      return arcs;
+    },
+
+    _render: function(colors, data) {
+      var arcs = this._calculateArcs(colors, data);
+      var svg = Polymer.dom(this.$.svg);
+
+      while (svg.firstChild) {
+        svg.removeChild(svg.firstChild);
+      }
+
+      for (i = 0; i < arcs.length; i++) {
+        var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.classList.add('slice');
+        path.style.fill = arcs[i].color;
+        path.setAttribute('d', this._computePath(arcs[i]));
+        svg.appendChild(path);
+      }
+    }
+  });
+})();
 </script>

--- a/svg-piechart.html
+++ b/svg-piechart.html
@@ -1,15 +1,28 @@
 <link rel="import" href="../polymer/polymer.html">
 
 <!--
-The `svg-piechart` element draws a piechart using SVG
+`svg-piechart` draws a piechart using SVG. The absolut values are defined as an array in `data`.
 
-##### Example
+    <svg-piechart data="[10,20,40,50]"></svg-piechart>
 
-    <svg-piechart size="50" data="[10,20,40,50]"></svg-piechart>
+Height and width in pixels can be changed by setting `size`:
+
+    <svg-piechart size="250" data="[10,20,40,50]"></svg-piechart>
+
+There are three default color palettes included. They all use the official <a href="http://www.google.com/design/spec/style/color.html">Material Colors</a>. One has 4 different colors, one 8 and one 16. The chart element automatically uses the smallest palette that covers the amount of given values. (So with 6 given values, the 8-color-palette is used.)
+
+To use custom colors, set the `colors` property to an array of rgb or rgba values:
+
+    <svg-piechart
+      colors='["red", "#666", "#1e88e5", "rgba(255, 0, 20, .4)"]'
+      data="  [ 10,    20,     40,        50]">
+    </svg-piechart>
+
+
 
 @demo
-@element svg-piechart
-@blurb Draws a piechart using DOM and CSS3
+@element
+@blurb Draws a piechart using SVG.
 @status alpha
 @homepage http://timeu.github.io/svg-piechart
 -->
@@ -20,7 +33,7 @@ The `svg-piechart` element draws a piechart using SVG
       display:block;
     }
 
-    .slice:hover + text {
+    .slice {
     }
    </style>
    
@@ -86,9 +99,7 @@ The `svg-piechart` element draws a piechart using SVG
       */
       colors: {
         type: Array,
-        value: function() {
-          return [];
-        }
+        value: []
       },
 
       /**
@@ -98,7 +109,7 @@ The `svg-piechart` element draws a piechart using SVG
       */
       size: {
         type: Number,
-        value: 50
+        value: 150
       },
 
       /**
@@ -106,12 +117,10 @@ The `svg-piechart` element draws a piechart using SVG
       * 
       * @attribute data
       */
-      data : {
+      data: {
         type: Array,
-        value: function() {
-          return [];
-        }
-      } 
+        value: []
+      }
     },
 
     observers: [
@@ -127,12 +136,11 @@ The `svg-piechart` element draws a piechart using SVG
     },
 
     _computePath: function(arc) {
-      return "M180,180 L" + arc.x1 + "," + arc.y1 + " A180,180 0 " + arc.largeArcFlag + ",1 " + arc.x2 + "," + arc.y2 + " z";
+      return 'M180,180 L' + arc.x1 + ',' + arc.y1 + ' A180,180 0 ' + arc.largeArcFlag + ',1 ' + arc.x2 + ',' + arc.y2 + ' z';
     },
 
     _getColors: function(colors) {
       if (!colors || colors.length == 0) {
-        // colors = this.data.length > 10  ? DEFAULT_COLORS20 : DEFAULT_COLORS10;
         if (this.data.length > 8) {
           colors = DEFAULT_COLORS16;
         }

--- a/svg-piechart.html
+++ b/svg-piechart.html
@@ -32,9 +32,6 @@ To use custom colors, set the `colors` property to an array of rgb or rgba value
     :host {
       display:block;
     }
-
-    .slice {
-    }
    </style>
    
    <template>
@@ -103,7 +100,7 @@ To use custom colors, set the `colors` property to an array of rgb or rgba value
       },
 
       /**
-      * The `size` property specifies the size of the piechart (Default: 50).
+      * The `size` property specifies the size of the piechart (Default: 150).
       * 
       * @attribute size
       */
@@ -157,7 +154,7 @@ To use custom colors, set the `colors` property to an array of rgb or rgba value
     _calculateArcs: function(colors, data) {
       var total = this._calculateTotal(data);
       var colors = this._getColors(colors);
-      var startAngle =  0;
+      var startAngle = 0;
       var endAngle = -90;
       var arcs = [];
 
@@ -177,7 +174,8 @@ To use custom colors, set the `colors` property to an array of rgb or rgba value
           x2: 180 + 180*Math.cos(Math.PI*endAngle/180),
           y2: 180 + 180*Math.sin(Math.PI*endAngle/180),
           largeArcFlag: largeArcFlag,
-          color: colors[i]});
+          color: colors[i]
+        });
       }
 
       return arcs;


### PR DESCRIPTION
First of all, thanks for the chart element! I've been using the google-chart but that element simply could "too much", so this one is great.

The demo/index.html file is used in the component page (svg-piechart/index.html). So it shouldn't be ignored with bower.

I replaced the 10- and 20-color-palettes with 4-, 8- and 16-color-palettes. They all use Google's material colors, which looks better.

The third commit contains improvements for demo and docs, also with the new color palettes. During editing the demo, I set the new default size to 150 (because that size looks "more normal", not small).

I also fixed the indentation, mostly in the script tag, and generalized things like spaces after if/for/while or single or double quotes (I changed to single ones).

I'd really appreciate if you could merge my pull request :) . The only change of the element behavior is the default size, so the possibility of bugs which affect the behavior of the elements is relatively low ;-) .
